### PR TITLE
[Refactor] add CLI and tests

### DIFF
--- a/edge_batch_runner.py
+++ b/edge_batch_runner.py
@@ -1,125 +1,220 @@
-import os
+#!/usr/bin/env python3.10
+"""Batch edge detection runner."""
+from __future__ import annotations
+
+import argparse
+import subprocess
 import sys
-import cv2
-import pathlib
-import urllib.request
 import tkinter as tk
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
 from tkinter import filedialog
-import tqdm
-from subprocess import run
+from typing import Callable, Dict
 
-# --- Pfaddefinitionen ------------------------------------
-MODEL_DIR = pathlib.Path("models")
+import cv2
+import numpy as np
+import torch
+from loguru import logger
+from tqdm import tqdm
+
+MODEL_DIR = Path("models")
 WEIGHT_DIR = MODEL_DIR / "weights"
-MODEL_DIR.mkdir(exist_ok=True)
-WEIGHT_DIR.mkdir(exist_ok=True)
+EXTENSIONS = {".jpg", ".jpeg", ".png", ".bmp", ".tif", ".tiff", ".webp"}
 
-# --- Modellbeschreibungen und Download --------------------
-def clone(url: str) -> pathlib.Path:
-    tgt = MODEL_DIR / pathlib.Path(url).stem
-    if not tgt.exists():
-        run(["git", "clone", "--depth", "1", url, str(tgt)])
-    return tgt
 
-MODELS = {
-    "pidinet": {
-        "repo": "https://github.com/hellozhuo/pidinet",
-        "url": "https://huggingface.co/lllyasviel/Annotators/resolve/main/table5_pidinet.pth",
-        "file": WEIGHT_DIR / "table5_pidinet.pth",
-    },
-    "diffedge": {
-        "repo": "https://github.com/GuHuangAI/DiffusionEdge",
-        "url": "https://huggingface.co/BRIAAI/DiffEdge/resolve/main/diffedge_swin.pth",
-        "file": WEIGHT_DIR / "diffedge_swin.pth",
-    },
-    "edter": {
-        "repo": "https://github.com/MengyangPu/EDTER",
-        "url": "https://download.openmmlab.com/mmsegmentation/v0.5/edter/edter_bsds.pth",
-        "file": WEIGHT_DIR / "edter_bsds.pth",
-    },
+@dataclass
+class ModelInfo:
+    repo: str
+    url: str
+    file: Path
+
+
+MODELS: Dict[str, ModelInfo] = {
+    "pidinet": ModelInfo(
+        repo="https://github.com/hellozhuo/pidinet",
+        url="https://huggingface.co/lllyasviel/Annotators/resolve/main/table5_pidinet.pth",
+        file=WEIGHT_DIR / "table5_pidinet.pth",
+    ),
+    "diffedge": ModelInfo(
+        repo="https://github.com/GuHuangAI/DiffusionEdge",
+        url="https://huggingface.co/BRIAAI/DiffEdge/resolve/main/diffedge_swin.pth",
+        file=WEIGHT_DIR / "diffedge_swin.pth",
+    ),
+    "edter": ModelInfo(
+        repo="https://github.com/MengyangPu/EDTER",
+        url="https://download.openmmlab.com/mmsegmentation/v0.5/edter/edter_bsds.pth",
+        file=WEIGHT_DIR / "edter_bsds.pth",
+    ),
 }
 
-# Klone Repos und lade Modelle herunter
-for m in MODELS.values():
-    clone(m["repo"])
-    if not m["file"].exists():
-        print(f"[Download] {m['file'].name}")
-        urllib.request.urlretrieve(m["url"], m["file"])
 
-# --- GUI-Auswahl für Eingabeordner ------------------------
-root = tk.Tk()
-root.withdraw()
-folder = filedialog.askdirectory(title="Bilderordner wählen")
-if not folder:
-    sys.exit()
-in_dir = pathlib.Path(folder)
+def run_cmd(cmd: list[str], cwd: Path | None = None) -> None:  # pragma: no cover
+    """Execute a subprocess."""
+    subprocess.run(cmd, cwd=cwd, check=True)
 
-# --- Bildformate & Ausgabeordner vorbereiten --------------
-EXT = {".jpg", ".jpeg", ".png", ".bmp", ".tif", ".tiff", ".webp"}
-out_dirs = {k: (in_dir / k) for k in MODELS}
-for d in out_dirs.values():
-    d.mkdir(exist_ok=True)
 
-# --- Bildverarbeitung -------------------------------------
-def to_line(gray):
+def clone_repo(url: str) -> Path:  # pragma: no cover
+    """Clone the model repository if necessary."""
+    path = MODEL_DIR / Path(url).stem
+    if not path.exists():
+        logger.info("Cloning {}", url)
+        run_cmd(["git", "clone", "--depth", "1", url, str(path)])
+    return path
+
+
+def download_weight(url: str, dst: Path) -> None:  # pragma: no cover
+    """Download the weight file if missing."""
+    if dst.exists():
+        return
+    logger.info("Downloading {}", dst.name)
+    urllib.request.urlretrieve(url, dst)
+
+
+def clear_vram() -> None:
+    """Release cached CUDA memory."""
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+
+def to_line(gray: np.ndarray) -> np.ndarray:
+    """Binarise a greyscale edge map."""
     if gray.mean() > 127:
         gray = 255 - gray
-    return cv2.threshold(gray, 32, 255, cv2.THRESH_BINARY)[1]
+    _, thr = cv2.threshold(gray, 32, 255, cv2.THRESH_BINARY)
+    return thr
 
-def clear_vram():
-    pass  # Platzhalter, falls CUDA oder Torch verwendet wird.
 
-# --- Modell-Aufrufe ---------------------------------------
-def call_pidinet(img, out):
-    r = MODEL_DIR / 'pidinet'
-    run([
-        sys.executable, r / 'demo.py',
-        '--config', r / 'configs/pidinet/table5_pidinet.yaml',
-        '--model', MODELS["pidinet"]["file"],
-        '--input', img,
-        '--save'
-    ])
-    tmp = pathlib.Path(img).with_suffix(".png").with_name(pathlib.Path(img).stem + "_edge.png")
-    cv2.imwrite(out, to_line(cv2.imread(str(tmp), 0)))
+def call_pidinet(img: Path, out: Path) -> None:  # pragma: no cover
+    """Run PiDiNet on one image."""
+    repo = MODEL_DIR / "pidinet"
+    run_cmd(
+        [
+            sys.executable,
+            str(repo / "demo.py"),
+            "--config",
+            str(repo / "configs/pidinet/table5_pidinet.yaml"),
+            "--model",
+            str(MODELS["pidinet"].file),
+            "--input",
+            str(img),
+            "--save",
+        ]
+    )
+    tmp = img.with_suffix(".png").with_name(img.stem + "_edge.png")
+    cv2.imwrite(str(out), to_line(cv2.imread(str(tmp), 0)))
     tmp.unlink(missing_ok=True)
     clear_vram()
 
-def call_diffedge(img, out):
-    r = MODEL_DIR / 'DiffusionEdge'
-    run([
-        sys.executable, r / 'demo.py',
-        '--checkpoint', MODELS["diffedge"]["file"],
-        '--input', img,
-        '--save', 'edge_tmp.png',
-        '--fp16'
-    ])
-    cv2.imwrite(out, to_line(cv2.imread('edge_tmp.png', 0)))
-    os.remove('edge_tmp.png')
+
+def call_diffedge(img: Path, out: Path) -> None:  # pragma: no cover
+    """Run DiffusionEdge on one image."""
+    repo = MODEL_DIR / "DiffusionEdge"
+    run_cmd(
+        [
+            sys.executable,
+            str(repo / "demo.py"),
+            "--checkpoint",
+            str(MODELS["diffedge"].file),
+            "--input",
+            str(img),
+            "--save",
+            "edge_tmp.png",
+            "--fp16",
+        ]
+    )
+    cv2.imwrite(str(out), to_line(cv2.imread("edge_tmp.png", 0)))
+    Path("edge_tmp.png").unlink()
     clear_vram()
 
-def call_edter(img, out):
-    r = MODEL_DIR / 'EDTER'
-    run([
-        sys.executable, r / 'demo/test_single.py',
-        '--config', r / 'configs/edter_bsds.py',
-        '--checkpoint', MODELS["edter"]["file"],
-        '--img', img,
-        '--out', 'edge_tmp.png'
-    ])
-    cv2.imwrite(out, to_line(cv2.imread('edge_tmp.png', 0)))
-    os.remove('edge_tmp.png')
+
+def call_edter(img: Path, out: Path) -> None:  # pragma: no cover
+    """Run EDTER on one image."""
+    repo = MODEL_DIR / "EDTER"
+    run_cmd(
+        [
+            sys.executable,
+            str(repo / "demo/test_single.py"),
+            "--config",
+            str(repo / "configs/edter_bsds.py"),
+            "--checkpoint",
+            str(MODELS["edter"].file),
+            "--img",
+            str(img),
+            "--out",
+            "edge_tmp.png",
+        ]
+    )
+    cv2.imwrite(str(out), to_line(cv2.imread("edge_tmp.png", 0)))
+    Path("edge_tmp.png").unlink()
     clear_vram()
 
-DISPATCH = {
+
+DISPATCH: Dict[str, Callable[[Path, Path], None]] = {
     "pidinet": call_pidinet,
     "diffedge": call_diffedge,
-    "edter": call_edter
+    "edter": call_edter,
 }
 
-# --- Batch-Verarbeitung -----------------------------------
-imgs = [p for p in in_dir.rglob("*") if p.suffix.lower() in EXT]
-for p in tqdm.tqdm(imgs):
-    for k, func in DISPATCH.items():
-        dst = out_dirs[k] / f"{p.stem}_{k}.png"
-        if not dst.exists():
-            func(str(p), str(dst))
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="Batch edge detection")
+    parser.add_argument("--input", type=Path, help="Folder with images")
+    parser.add_argument("--streamlit", action="store_true", help="Run with Streamlit GUI")
+    args, unknown = parser.parse_known_args(argv)
+    if unknown:
+        logger.error("Unknown arguments: %s", unknown)
+        sys.exit(40)
+    return args
+
+
+def choose_input_dir(given: Path | None) -> Path:
+    """Return the input directory, using Tkinter if not provided."""
+    if given:
+        return given
+    root = tk.Tk()
+    root.withdraw()
+    folder = filedialog.askdirectory(title="Select the image folder")
+    if not folder:
+        raise ValueError("No folder selected")
+    return Path(folder)
+
+
+def setup_models() -> None:
+    """Ensure all models and weights are present."""
+    MODEL_DIR.mkdir(exist_ok=True)
+    WEIGHT_DIR.mkdir(exist_ok=True)
+    for cfg in MODELS.values():
+        clone_repo(cfg.repo)
+        download_weight(cfg.url, cfg.file)
+
+
+def process_images(in_dir: Path) -> None:  # pragma: no cover
+    """Run all models on images inside the directory."""
+    out_dirs = {k: in_dir / k for k in MODELS}
+    for d in out_dirs.values():
+        d.mkdir(exist_ok=True)
+    imgs = [p for p in in_dir.rglob("*") if p.suffix.lower() in EXTENSIONS]
+    for img in tqdm(imgs, desc="processing"):
+        for name, func in DISPATCH.items():
+            dst = out_dirs[name] / f"{img.stem}_{name}.png"
+            if not dst.exists():
+                func(img, dst)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point."""
+    args = parse_args(argv)
+    try:
+        input_dir = choose_input_dir(args.input)
+    except ValueError as exc:
+        logger.error(str(exc))
+        return 20
+    setup_models()
+    process_images(input_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,49 @@
+import argparse
+from pathlib import Path
+from unittest import mock
+
+import numpy as np
+
+import edge_batch_runner as ebr
+
+
+def test_to_line_inverts_and_thresholds():
+    gray = np.array([[255, 255], [255, 255]], dtype=np.uint8)
+    result = ebr.to_line(gray)
+    assert result.max() == 0
+    assert result.min() == 0
+
+
+def test_parse_args_unknown(monkeypatch):
+    with mock.patch.object(
+        argparse.ArgumentParser,
+        "parse_known_args",
+        return_value=(argparse.Namespace(input=None, streamlit=False), ["--bad"]),
+    ):
+        with mock.patch.object(ebr.logger, "error") as log_err:
+            with mock.patch.object(ebr.sys, "exit") as exit_mock:
+                ebr.parse_args([])
+                exit_mock.assert_called_with(40)
+                log_err.assert_called()
+
+
+def test_choose_dir_from_arg():
+    path = Path("some_dir")
+    assert ebr.choose_input_dir(path) == path
+
+
+def test_clear_vram_calls_torch():
+    with mock.patch("edge_batch_runner.torch") as torch_mock:
+        torch_mock.cuda.is_available.return_value = True
+        ebr.clear_vram()
+        torch_mock.cuda.empty_cache.assert_called()
+
+
+def test_main_runs(monkeypatch, tmp_path):
+    calls = {}
+    monkeypatch.setattr(ebr, "clone_repo", lambda repo: calls.setdefault("clone", True))
+    monkeypatch.setattr(ebr, "download_weight", lambda url, dst: calls.setdefault("download", True))
+    monkeypatch.setattr(ebr, "process_images", lambda path: calls.setdefault("process", path))
+    result = ebr.main(["--input", str(tmp_path)])
+    assert result == 0
+    assert calls["process"] == tmp_path


### PR DESCRIPTION
## Summary
- rewrite edge_batch_runner with argparse CLI and type hints
- add unit tests for helper functions and main path
- configure coverage exclusion for runtime-heavy functions

## Testing
- `mypy --strict --ignore-missing-imports --no-site-packages edge_batch_runner.py`
- `flake8 --max-line-length 120 edge_batch_runner.py tests/test_runner.py`
- `pytest --maxfail=1 --disable-warnings -q`
- `coverage run --source edge_batch_runner -m pytest -q`
- `coverage report -m`
- `python3 edge_batch_runner.py --help`


------
https://chatgpt.com/codex/tasks/task_e_6845dd4951b883279453f12e0abc7d27