### PR TITLE
Add robust weight download and optional torch

### DIFF
--- a/download_models.py
+++ b/download_models.py
@@ -10,9 +10,16 @@ download_models.py – robust multi-mirror fetcher for PiDiNet, DiffusionEdge, E
 """
 
 from __future__ import annotations
-import hashlib, os, re, shutil, subprocess, sys, time
+
+import hashlib
+import re
+import shutil
+import subprocess
+import sys
+import time
 from pathlib import Path
-from typing import List, Dict
+from typing import Dict, List
+
 import requests
 
 # ---------------------------------------------------------------------------- #
@@ -41,7 +48,7 @@ MODELS: Dict[str, Dict] = {
         "urls": [
             # small 43-MB first-stage weight (GitHub release) 3
             "https://github.com/GuHuangAI/DiffusionEdge/releases/download/v1.1/first_stage_total_320.pt",
-            # full SWIN weights (1.2 GB, public HF mirror, three domains) 
+            # full SWIN weights (1.2 GB, public HF mirror, three domains)
             "https://huggingface.co/hr16/Diffusion-Edge/resolve/main/diffusion_edge_natrual.pt",
             "https://huggingface.co/hr16/Diffusion-Edge/resolve/main/diffusion_edge_urban.pt",
             "https://huggingface.co/hr16/Diffusion-Edge/resolve/main/diffusion_edge_indoor.pt",
@@ -82,7 +89,7 @@ def gdrive_download(url: str, dst: Path) -> bool:
     if "drive.google.com" not in url:
         return False
     if shutil.which("gdown"):
-        cmd = ["gdown", "--fuzzy", url, "-O", dst]
+        cmd = ["gdown", "--fuzzy", url, "-O", str(dst)]
         return subprocess.call(cmd) == 0 and dst.exists()
 
     # manual fallback (wget two-step)
@@ -93,9 +100,7 @@ def gdrive_download(url: str, dst: Path) -> bool:
     response = session.get(url, stream=True)
     confirm = re.search(r"confirm=([0-9A-Za-z_]+)", response.text)
     if confirm:
-        dl_url = (
-            f"https://drive.google.com/uc?export=download&confirm={confirm.group(1)}&id={file_id.group(1)}"
-        )
+        dl_url = f"https://drive.google.com/uc?export=download&confirm={confirm.group(1)}&id={file_id.group(1)}"
         response = session.get(dl_url, stream=True)
     if response.status_code != 200:
         return False

--- a/edge_batch_runner.py
+++ b/edge_batch_runner.py
@@ -14,7 +14,11 @@ from typing import Callable, Dict
 
 import cv2
 import numpy as np
-import torch
+
+try:  # pragma: no cover - optional dependency
+    import torch
+except Exception:  # pragma: no cover - no torch available
+    torch = None  # type: ignore
 from loguru import logger
 from tqdm import tqdm
 
@@ -73,7 +77,7 @@ def download_weight(url: str, dst: Path) -> None:  # pragma: no cover
 
 def clear_vram() -> None:
     """Release cached CUDA memory."""
-    if torch.cuda.is_available():
+    if torch is not None and torch.cuda.is_available():
         torch.cuda.empty_cache()
 
 
@@ -161,7 +165,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(description="Batch edge detection")
     parser.add_argument("--input", type=Path, help="Folder with images")
-    parser.add_argument("--streamlit", action="store_true", help="Run with Streamlit GUI")
+    parser.add_argument(
+        "--streamlit", action="store_true", help="Run with Streamlit GUI"
+    )
     args, unknown = parser.parse_known_args(argv)
     if unknown:
         logger.error("Unknown arguments: %s", unknown)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -42,8 +42,12 @@ def test_clear_vram_calls_torch():
 def test_main_runs(monkeypatch, tmp_path):
     calls = {}
     monkeypatch.setattr(ebr, "clone_repo", lambda repo: calls.setdefault("clone", True))
-    monkeypatch.setattr(ebr, "download_weight", lambda url, dst: calls.setdefault("download", True))
-    monkeypatch.setattr(ebr, "process_images", lambda path: calls.setdefault("process", path))
+    monkeypatch.setattr(
+        ebr, "download_weight", lambda url, dst: calls.setdefault("download", True)
+    )
+    monkeypatch.setattr(
+        ebr, "process_images", lambda path: calls.setdefault("process", path)
+    )
     result = ebr.main(["--input", str(tmp_path)])
     assert result == 0
     assert calls["process"] == tmp_path


### PR DESCRIPTION
## Summary
- refine `download_models.py` imports and gdown call
- make `edge_batch_runner` tolerant when PyTorch is missing
- format tests and configure flake8 length

## Testing
- `flake8 .`
- `mypy --ignore-missing-imports .`
- `coverage run --omit="*config*.py,*/site-packages/*" -m pytest`
- `coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_68460f25067c832782c99bbfb47f5889